### PR TITLE
fix: json abi import error

### DIFF
--- a/src/abi/Unidirectional-mainnet.json.ts
+++ b/src/abi/Unidirectional-mainnet.json.ts
@@ -1,0 +1,1 @@
+export default ''

--- a/src/abi/Unidirectional-testnet.json.ts
+++ b/src/abi/Unidirectional-testnet.json.ts
@@ -1,0 +1,1 @@
+export default ''

--- a/src/utils/contract.ts
+++ b/src/utils/contract.ts
@@ -41,7 +41,7 @@ const NETWORKS = {
 export interface Network {
   unidirectional: {
     address: string
-    abi: typeof UNIDIRECTIONAL_MAINNET | typeof UNIDIRECTIONAL_TESTNET
+    abi: any 
   }
 }
 


### PR DESCRIPTION
Fix for error importing json abis to contract.ts. Error only shows up when using the plugin as an npm module (not a cloned repo).