### PR TITLE
Added prepublishOnly build npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsc || true",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "lint": "tslint --project .",
     "test": "nyc ava",
     "test-inspect": "node --inspect node_modules/ava/profile.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilp-plugin-ethereum",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "Settle Interledger payments with ether and ERC-20 tokens",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepublish": "npm run build",
     "lint": "tslint --project .",
     "test": "nyc ava",
     "test-inspect": "node --inspect node_modules/ava/profile.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc || true",
     "prepare": "npm run build",
     "lint": "tslint --project .",
     "test": "nyc ava",
@@ -59,7 +59,7 @@
     "ava": "^1.0.0-rc.1",
     "codecov": "^3.1.0",
     "get-port": "^4.0.0",
-    "ilp-protocol-stream": "github:interledgerjs/ilp-protocol-stream#ko-receive-only",
+    "ilp-protocol-stream": "github:interledgerjs/ilp-protocol-stream#ko-receive-only-tests",
     "nyc": "^13.0.1",
     "standard": "^11.0.1",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "lint": "tslint --project .",
     "test": "nyc ava",
     "test-inspect": "node --inspect node_modules/ava/profile.js"


### PR DESCRIPTION
The [ilp-plugin-ethereum-3.0.0-beta.4.tgz](https://registry.npmjs.org/ilp-plugin-ethereum/-/ilp-plugin-ethereum-3.0.0-beta.4.tgz) does not contain a build folder.