### PR TITLE
fix: re-try validating claims after possible funding transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -630,9 +630,9 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/get-port": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-4.0.0.tgz",
-      "integrity": "sha512-Zp1GxOt3GNbIQqz2hSHSH7LALpTPvPHMA/aYut3VeitDgGwqcXEVvDQWWP3kPABsh3CGSHPSt67DN6jnc7oJMA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-4.0.1.tgz",
+      "integrity": "sha512-rPeWy62y0uG7kDT2676V7Ix/UDwAgGqbClhM+h4SlUBvoov3/QOUFXad9xmFGCU2DEGxhFeXbGeZU3kG2KMXRg==",
       "dev": true
     },
     "@types/node": {
@@ -641,9 +641,9 @@
       "integrity": "sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ=="
     },
     "@types/p-queue": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.1.tgz",
-      "integrity": "sha512-JyO7uMAtkcMMULmsTQ4t/lCC8nxirTtweGG1xAFNNIAoC1RemmeIxq8PiKghuEy99XdbS6Lwx4zpbXUjfeSSAA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-3.0.0.tgz",
+      "integrity": "sha512-brMFTEZiltJnAxNy07LzRVw2bdQX1ElCElHEmo5WEI70oWQe00aXew9RKmpf8MOzBMiMfNeuQoEyQCWKawPzmQ==",
       "dev": true
     },
     "@types/underscore": {
@@ -652,9 +652,9 @@
       "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q=="
     },
     "@types/web3": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.11.tgz",
-      "integrity": "sha512-45puQrp3ubVTOa6ezkdgQqaj4nwmvOn1vI1GLfA7Q6cZdIRDpFhmg/Mue9rUTaQuhfeXMCUSZ71zbozHpQJ17w==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.14.tgz",
+      "integrity": "sha512-N841xEBVwg0QNin3Zu+Yf7eEKKeJ0MROMc+FvfgtX8r/fwynFhSZVj3VONVcr9QP/Wffq+aggj+4lgrvG3lnFQ==",
       "requires": {
         "@types/bn.js": "*",
         "@types/underscore": "*"
@@ -856,21 +856,10 @@
       }
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
     },
     "aes-js": {
       "version": "3.0.0",
@@ -889,9 +878,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
     "ansi-align": {
@@ -2580,7 +2569,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -2889,50 +2878,76 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.18.2",
-      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
+      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
         "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^6.0.5",
         "debug": "^3.1.0",
         "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
-        "esquery": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.2",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
         "pluralize": "^7.0.0",
         "progress": "^2.0.0",
+        "regexpp": "^2.0.0",
         "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
+        "semver": "^5.5.0",
         "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2941,6 +2956,24 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.1",
@@ -2960,15 +2993,15 @@
       }
     },
     "eslint-config-standard": {
-      "version": "11.0.0",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-      "integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
+      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -3041,22 +3074,32 @@
         }
       }
     },
-    "eslint-plugin-import": {
-      "version": "2.9.0",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
-      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+    "eslint-plugin-es": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
         "contains-path": "^0.1.0",
         "debug": "^2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
+        "eslint-module-utils": "^2.2.0",
         "has": "^1.0.1",
         "lodash": "^4.17.4",
         "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "debug": {
@@ -3175,50 +3218,67 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^4.0.2",
         "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.7.0",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.0.2",
-        "has": "^1.0.1",
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2"
       }
     },
     "eslint-plugin-standard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
     "eslint-scope": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3253,13 +3313,22 @@
       }
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -3971,46 +4040,15 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
-      },
-      "dependencies": {
-        "del": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
-          "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        }
       }
     },
     "flush-write-stream": {
@@ -4992,14 +5030,20 @@
       }
     },
     "ilp-logger": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.1.2.tgz",
-      "integrity": "sha512-LTPA2cwtBGOSiHuspdESKRXQT8CCoGVIUQAeHlNKDz132qwtwwd7KPVWAbGkZer7EQaLW1Cwa9vGR61sSYINww==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.1.3.tgz",
+      "integrity": "sha512-zjCe82YGI1SMnwDf2GGKhGqx0V4UcpReZSiYuBy9KvyOW08Da4geOJfhNd+h9jczDIQ+mFxrbeKoBa/Zbs/5xw==",
       "requires": {
-        "@types/debug": "^0.0.30",
-        "debug": "^4.0.0",
-        "source-map-support": "^0.5.9",
+        "@types/debug": "^0.0.31",
+        "debug": "^4.1.0",
         "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@types/debug": {
+          "version": "0.0.31",
+          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
+          "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A=="
+        }
       }
     },
     "ilp-packet": {
@@ -5260,22 +5304,21 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "5.2.0",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
+        "external-editor": "^2.1.0",
         "figures": "^2.0.0",
         "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
+        "rxjs": "^5.5.2",
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
@@ -8207,9 +8250,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -8506,6 +8549,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
@@ -8556,7 +8605,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -8737,19 +8786,21 @@
         "aproba": "^1.1.1"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -9193,6 +9244,7 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -9280,26 +9332,26 @@
       "dev": true
     },
     "standard": {
-      "version": "11.0.1",
-      "resolved": "http://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
-      "integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
+      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
       "dev": true,
       "requires": {
-        "eslint": "~4.18.0",
-        "eslint-config-standard": "11.0.0",
-        "eslint-config-standard-jsx": "5.0.0",
-        "eslint-plugin-import": "~2.9.0",
-        "eslint-plugin-node": "~6.0.0",
-        "eslint-plugin-promise": "~3.7.0",
-        "eslint-plugin-react": "~7.7.0",
-        "eslint-plugin-standard": "~3.0.1",
-        "standard-engine": "~8.0.0"
+        "eslint": "~5.4.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-config-standard-jsx": "6.0.2",
+        "eslint-plugin-import": "~2.14.0",
+        "eslint-plugin-node": "~7.0.1",
+        "eslint-plugin-promise": "~4.0.0",
+        "eslint-plugin-react": "~7.11.1",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "~9.0.0"
       }
     },
     "standard-engine": {
-      "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
-      "integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
+      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
       "dev": true,
       "requires": {
         "deglob": "^2.1.0",
@@ -9531,17 +9583,43 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "4.0.3",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
         "chalk": "^2.1.0",
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "tapable": {
@@ -9786,9 +9864,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
+      "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -9814,9 +9892,9 @@
       }
     },
     "tslint-config-standard": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-7.1.0.tgz",
-      "integrity": "sha512-cETzxZcEQ1RKjwtEScGryAtqwiRFc55xBxhZP6bePyOfXmo6i1/QKQrTgFKBiM4FjCvcqTjJq20/KGrh+TzTfQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-8.0.1.tgz",
+      "integrity": "sha512-OWG+NblgjQlVuUS/Dmq3ax2v5QDZwRx4L0kEuDi7qFY9UI6RJhhNfoCV1qI4el8Fw1c5a5BTrjQJP0/jhGXY/Q==",
       "dev": true,
       "requires": {
         "tslint-eslint-rules": "^5.3.1"
@@ -9862,9 +9940,9 @@
           "dev": true
         },
         "tsutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.2.0.tgz",
-          "integrity": "sha512-CvWEadl8VwlxOq6F3hfNbGrrRVSAjN2EPCEBgcbCUVDUxmwkV5254OGKsITNxDz8IGDQPAw7YJMtBHniHu2tbA==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.2.tgz",
+          "integrity": "sha512-qIlklNuI/1Dzfm+G+kJV5gg3gimZIX5haYtIVQe7qGyKd7eu8T1t1DY6pz4Sc2CGXAj9s1izycctm9Zfl9sRuQ==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"
@@ -9931,9 +10009,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.4.tgz",
-      "integrity": "sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
     },
     "uglify-es": {

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
   "homepage": "https://github.com/interledgerjs/ilp-plugin-ethereum#readme",
   "dependencies": {
     "@types/ethereumjs-util": "^5.2.0",
-    "@types/web3": "^1.0.5",
+    "@types/web3": "^1.0.14",
     "bignumber.js": "^7.2.1",
     "btp-packet": "^2.2.0",
     "debug": "^4.0.0",
     "eth-crypto": "^1.2.7",
     "ethereumjs-util": "^5.2.0",
     "eventemitter2": "^5.0.1",
-    "ilp-logger": "^1.0.2",
+    "ilp-logger": "^1.1.3",
     "ilp-packet": "^3.0.8",
     "ilp-plugin-btp": "^1.3.7",
     "ilp-plugin-mini-accounts": "^4.0.2",
@@ -57,17 +57,17 @@
     "web3": "^1.0.0-beta.37"
   },
   "devDependencies": {
-    "@types/get-port": "^4.0.0",
-    "@types/p-queue": "^2.3.1",
+    "@types/get-port": "^4.0.1",
+    "@types/p-queue": "^3.0.0",
     "ava": "^1.0.1",
     "codecov": "^3.1.0",
     "get-port": "^4.0.0",
     "ilp-protocol-stream": "github:interledgerjs/ilp-protocol-stream#3fe1f02273c8ac60927d902c7a88c45111c5699b",
     "nyc": "^13.0.1",
-    "standard": "^11.0.1",
+    "standard": "^12.0.1",
     "ts-node": "^7.0.1",
-    "tslint": "^5.11.0",
-    "tslint-config-standard": "^7.1.0",
-    "typescript": "^3.1.1"
+    "tslint": "^5.12.0",
+    "tslint-config-standard": "^8.0.1",
+    "typescript": "^3.2.2"
   }
 }

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -18,7 +18,7 @@ test('client streams data and money to server', async t => {
 
   const ethereumProvider = new Web3.providers.HttpProvider(process.env.ETHEREUM_PROVIDER!)
 
-  const port = await (getPort() as Promise<number>)
+  const port = await getPort()
 
   const clientPlugin = new EthereumPlugin({
     role: 'client',

--- a/src/__tests__/watcher.test.ts
+++ b/src/__tests__/watcher.test.ts
@@ -12,7 +12,7 @@ test(`channel watcher claims settling channel if it's profitable`, async t => {
   const ethereumProvider = new Web3.providers.HttpProvider(process.env.ETHEREUM_PROVIDER!)
   const web3 = new Web3(ethereumProvider)
 
-  const port = await (getPort() as Promise<number>)
+  const port = await getPort()
 
   const clientStore = new MemoryStore()
   const clientPlugin = new EthereumPlugin({

--- a/src/account.ts
+++ b/src/account.ts
@@ -721,12 +721,15 @@ export default class EthereumAccount {
     const retryValidation = () => {
       if (retryInterval < 10000) {
         this.master._log.trace(`Will retry validating the claim in ${retryInterval} ms`)
+
         const nextRetryInterval = Math.floor(retryInterval * 1.5)
         setTimeout(() =>
           this.validateClaim(claim, nextRetryInterval).catch(err =>
             this.master._log.error(`Attempt to retry claim validation failed: ${err.message}`)
           ),
         retryInterval)
+      } else {
+        this.master._log.trace(`Failed to validate claim: can't certify updated channel state, despite several attempts. Will not retry.`)
       }
     }
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -16,7 +16,9 @@ import {
   IlpPacket,
   Errors,
   errorToReject,
-  deserializeIlpPrepare
+  deserializeIlpPrepare,
+  isFulfill,
+  isReject
 } from 'ilp-packet'
 import EthereumPlugin from '.'
 import { randomBytes } from 'crypto'
@@ -382,6 +384,11 @@ export default class EthereumAccount {
       // Only on-chain tx fees and outgoing payment channel claims should impact the settle amount
       const value = BigNumber.max(settlementBudget, this.master._outgoingChannelAmount)
 
+      if (!(requiresNewChannel || requiresDeposit)) {
+        this.master._log.trace(`No on-chain funding transaction required to settle ${format(settlementBudget, Unit.Wei)} with account ${this.account.accountName}`)
+        return settlementBudget
+      }
+
       if (requiresNewChannel) {
         await this.fetchEthereumAddress()
         if (!this.account.ethereumAddress) {
@@ -413,11 +420,11 @@ export default class EthereumAccount {
         this.master._log.trace(`Opening channel for ${format(value, Unit.Wei)} and fee of ${format(txFee, Unit.Wei)} with ${this.account.accountName}`)
         const emitter = this.master._web3.eth.sendTransaction(tx) as unknown as EventEmitter2
 
-        await new Promise(resolve => {
+        await new Promise((resolve, reject) => {
           emitter.on('confirmation', (confNumber: number, receipt: TransactionReceipt) => {
             if (!receipt.status) {
               this.master._log.error(`Failed to open channel: on-chain transaction reverted by the EVM`)
-              resolve()
+              reject()
             } else if (confNumber >= 1) {
               this.master._log.info(`Successfully opened new channel ${channelId} for ${format(value, Unit.Wei)} `
                 + `and linked to account ${this.account.accountName}`)
@@ -427,16 +434,29 @@ export default class EthereumAccount {
           })
 
           emitter.on('error', (err: Error) => {
-            // For safety, if the tx is reverted, wasn't mined, or less gas was used, DO NOT credit the client's account
+            // For safety, if the tx is reverted, wasn't mined, or less gas was used, DO NOT credit the peer's account
             this.master._log.error(`Failed to open channel: ${err.message}`)
-            resolve()
+            reject()
           })
         })
 
         emitter.removeAllListeners()
 
-        // Wait 2 seconds for block to propagate
-        await new Promise(resolve => setTimeout(resolve, 2000))
+        // Ensure that we've successfully fetched the channel details before sending a claim
+        const refreshChannel = async (attempts = 0) => {
+          if (attempts > 50) {
+            throw new Error('Unable to lookup newly opened channel after 50 attempts despite 1 block confirmation')
+          }
+
+          const channel = this.channelCache[channelId]
+            || await this.updateChannelCache(channelId)
+          if (!channel) {
+            await new Promise(r => setTimeout(r, 200))
+            await refreshChannel(attempts += 1)
+          }
+        }
+
+        await refreshChannel()
       } else if (requiresDeposit) {
         const channelId = this.account.outgoingChannelId!
         const txObj = this.master._contract!.methods.deposit(channelId)
@@ -458,11 +478,11 @@ export default class EthereumAccount {
         this.master._log.trace(`Depositing ${format(txFee, Unit.Wei)} to channel for fee of ${format(txFee, Unit.Wei)} with account ${this.account.accountName}`)
         const emitter = this.master._web3.eth.sendTransaction(tx) as unknown as EventEmitter2
 
-        await new Promise(resolve => {
+        await new Promise((resolve, reject) => {
           emitter.on('confirmation', (confNumber: number, receipt: TransactionReceipt) => {
             if (!receipt.status) {
               this.master._log.error(`Failed to deposit to channel: on-chain transaction reverted by the EVM`)
-              resolve()
+              reject()
             } else if (confNumber >= 1) {
               this.master._log.info(`Successfully deposited ${format(value, Unit.Wei)} to channel ${channelId} for account ${this.account.accountName}`)
               resolve()
@@ -470,24 +490,36 @@ export default class EthereumAccount {
           })
 
           emitter.on('error', (err: Error) => {
-            // For safety, if the tx is reverted, wasn't mined, or less gas was used, DO NOT credit the client's account
+            // For safety, if the tx is reverted, wasn't mined, or less gas was used, DO NOT credit the peer's account
             this.master._log.error(`Failed to open channel: ${err.message}`)
-            resolve()
+            reject()
           })
         })
 
         emitter.removeAllListeners()
 
-        // Wait 2 seconds for block to propagate
-        await new Promise(resolve => setTimeout(resolve, 2000))
-      } else {
-        this.master._log.trace(`No on-chain funding transaction required to settle ${format(settlementBudget, Unit.Wei)} with account ${this.account.accountName}`)
+        // Ensure that we've successfully fetched the updated channel details before sending a new claim
+        const refreshChannel = async (attempts = 0) => {
+          if (attempts > 50) {
+            throw new Error('Unable to lookup new channel details after 50 attempts despite 1 block confirmation')
+          }
+
+          const channel = this.channelCache[channelId]
+            || await this.updateChannelCache(channelId)
+          const updatedChannelValue = channel.value.eq(value)
+          if (!updatedChannelValue) {
+            await new Promise(r => setTimeout(r, 200))
+            await refreshChannel(attempts += 1)
+          }
+        }
+
+        await refreshChannel()
       }
     } catch (err) {
       this.master._log.error(`Failed to fund outgoing channel to ${this.account.accountName}: ${err.message}`)
-    } finally {
-      return settlementBudget
     }
+
+    return settlementBudget
   }
 
   private async sendClaim (settlementBudget: BigNumber): Promise<BigNumber> {
@@ -567,9 +599,9 @@ export default class EthereumAccount {
       )
     } catch (err) {
       this.master._log.error(`Failed to send claim to ${this.account.accountName}: ${err.message}`)
-    } finally {
-      return settlementBudget
     }
+
+    return settlementBudget
   }
 
   async handleData (message: BtpPacket): Promise<BtpSubProtocol[]> {
@@ -652,137 +684,161 @@ export default class EthereumAccount {
   }
 
   async handleMoney (message: BtpPacket): Promise<BtpSubProtocol[]> {
-    return this.queue.add(async () => {
-      try {
-        const machinomy = getSubprotocol(message, 'machinomy')
+    try {
+      const machinomy = getSubprotocol(message, 'machinomy')
+      if (machinomy) {
+        this.master._log.trace(`Handling Machinomy claim for account ${this.account.accountName}`)
 
-        if (machinomy) {
-          this.master._log.trace(`Handling Machinomy claim for account ${this.account.accountName}`)
+        const claim = JSON.parse(machinomy.data.toString())
 
-          const claim = JSON.parse(machinomy.data.toString())
-
-          const hasValidSchema = (o: any): o is IClaim =>
-            typeof o.value === 'string'
-              && typeof o.channelId === 'string'
-              && typeof o.signature === 'string'
-          if (!hasValidSchema(claim)) {
-            throw new Error(`claim schema is malformed`)
-          }
-
-          const oldClaim = this.account.bestIncomingClaim
-          const wrongChannel = oldClaim
-            // New claim is using different channel from the old claim
-            && oldClaim.channelId !== claim.channelId
-            // Old channel is still open (if it was closed, a new claim is acceptable)
-            && (await this.updateChannelCache(oldClaim.channelId))
-          if (wrongChannel) {
-            throw new Error(`account ${this.account.accountName} must use channel ${oldClaim!.channelId}`)
-          }
-
-          let channel: IChannel | undefined = this.channelCache[claim.channelId]
-          // Fetch channel state from network if:
-          // 1) No claim/channel is linked to the account
-          // 2) The channel isn't cached
-          // 3) Claim value is greater than cached channel value (e.g. possible on-chain deposit)
-          const shouldFetchChannel = !oldClaim || !channel
-            || new BigNumber(claim.value).gt(channel.value)
-          if (shouldFetchChannel) {
-            channel = await this.updateChannelCache(claim.channelId)
-          }
-
-          if (!channel) {
-            throw new Error(`channel ${claim.channelId} is already closed or doesn't exist`)
-          }
-
-          if (new BigNumber(claim.value).lte(0)) {
-            throw new Error(`value of claim is 0 or negative`)
-          }
-
-          const contractAddress = this.master._network!.unidirectional.address
-          const paymentDigest = Web3.utils.soliditySha3(contractAddress, claim.channelId, claim.value)
-          const paymentDigestBuffer = Buffer.from(Web3.utils.hexToBytes(paymentDigest))
-          const ethPaymentDigest = Buffer.concat([
-            Buffer.from(SIGN_PREFIX), paymentDigestBuffer
-          ])
-          const senderAddress = ethRecover(claim.signature, keccak256(ethPaymentDigest))
-          const isValidSignature = senderAddress === channel.sender
-          if (!isValidSignature) {
-            throw new Error(`signature is invalid, or sender is using contracts on a different network`)
-          }
-
-          const oldClaimValue = new BigNumber(oldClaim ? oldClaim.value : 0)
-          const newClaimValue = BigNumber.min(channel.value, claim.value)
-          let claimIncrement = newClaimValue.minus(oldClaimValue)
-          if (claimIncrement.eq(0)) {
-            this.master._log.trace(`Disregarding incoming claim: value of ${format(claim.value, Unit.Wei)} is same as previous claim`)
-            // Respond to the request normally, not with an error:
-            // Peer may have deposited to the channel and think it's confirmed, but we don't see it yet, causing them to send
-            // a claim value greater than the amount that's in the channel
-            return []
-          } else if (claimIncrement.lt(0)) {
-            throw new Error(`claim value of ${format(claim.value, Unit.Wei)} is less than previous claim for ${format(oldClaimValue, Unit.Wei)}`)
-          }
-
-          // If a new channel is being linked to the account, perform additional validation
-          const linkNewChannel = !oldClaim || claim.channelId !== oldClaim.channelId
-          if (linkNewChannel) {
-            // Each channel key is a mapping of channelId -> accountName to ensure no channel can be linked to multiple accounts
-            // No race condition: a new linked channel will be cached at the end of this closure
-            const channelKey = `${claim.channelId}:incoming-channel`
-            await this.master._store.load(channelKey)
-            const linkedAccount = this.master._store.get(channelKey)
-            const canLinkChannel = !linkedAccount || linkedAccount === this.account.accountName
-            if (!canLinkChannel) {
-              throw new Error(`channel ${claim.channelId} is already linked to a different account`)
-            }
-
-            // Check the channel is to the server's address
-            // (only check for new channels, not per claim, in case the server restarts and changes config)
-            const amReceiver = channel.receiver.toLowerCase() === this.master._ethereumAddress.toLowerCase()
-            if (!amReceiver) {
-              throw new Error(`the recipient for incoming channel ${claim.channelId} is not ${this.master._ethereumAddress}`)
-            }
-
-            // Confirm the settling period for the channel is above the minimum
-            const isAboveMinSettlementPeriod = channel.settlingPeriod.gte(this.master._minIncomingSettlementPeriod)
-            if (!isAboveMinSettlementPeriod) {
-              throw new Error(`channel ${channel.channelId} has settling period of ${channel.settlingPeriod} blocks,`
-                + `below floor of ${this.master._minIncomingSettlementPeriod} blocks`)
-            }
-
-            // Deduct the initiation fee (e.g. this could be used to cover the cost of the claim tx to close the channel)
-            claimIncrement = claimIncrement.minus(this.master._incomingChannelFee)
-            if (claimIncrement.lt(0)) {
-              throw new Error(`claim value of ${format(newClaimValue, Unit.Wei)} is insufficient to cover the initiation fee of ` +
-                `${format(this.master._incomingChannelFee, Unit.Wei)}`)
-            }
-
-            this.master._store.set(channelKey, this.account.accountName)
-            this.master._log.trace(`Incoming channel ${claim.channelId} is now linked to account ${this.account.accountName}`)
-          }
-
-          this.account.bestIncomingClaim = claim
-          this.master._log.info(`Accepted incoming claim from account ${this.account.accountName} for ${format(claimIncrement, Unit.Wei)}`)
-
-          // Start the channel watcher if it wasn't running
-          if (!this.watcher) {
-            this.watcher = this.startChannelWatcher()
-          }
-
-          const amount = convert(claimIncrement, Unit.Wei, Unit.Gwei).dp(0, BigNumber.ROUND_DOWN)
-          this.subBalance(amount)
-
-          await this.moneyHandler(amount.toString())
-        } else {
-          throw new Error(`BTP TRANSFER packet did not include any 'machinomy' subprotocol data`)
+        const hasValidSchema = (o: any): o is IClaim =>
+          typeof o.value === 'string'
+            && typeof o.channelId === 'string'
+            && typeof o.signature === 'string'
+        if (!hasValidSchema(claim)) {
+          throw new Error(`claim schema is malformed`)
         }
 
-        return []
-      } catch (err) {
-        this.master._log.trace(`Failed to validate claim: ${err.message}`)
-        // Don't expose internal errors: this could be problematic if an error wasn't intentionally thrown
-        throw new Error('Invalid claim')
+        await this.validateClaim(claim)
+      } else {
+        throw new Error(`BTP TRANSFER packet did not include any 'machinomy' subprotocol data`)
       }
+
+      return []
+    } catch (err) {
+      this.master._log.trace(`Failed to validate claim: ${err.message}`)
+      // Don't expose internal errors: this could be problematic if an error wasn't intentionally thrown
+      throw new Error('Invalid claim')
+    }
+  }
+
+  private validateClaim (claim: IClaim, retryInterval = 10): Promise<void> {
+    /**
+     * In case of an on-chain funding tx, the peer may know about it before we do.
+     * This allows time for the updated state to propagate to our Ethereum provider
+     * Retry validating the claim ~11 times, backing off up to 10 seconds
+     */
+    const retryValidation = () => {
+      if (retryInterval < 10000) {
+        this.master._log.trace(`Will retry validating the claim in ${retryInterval} ms`)
+        const nextRetryInterval = Math.floor(retryInterval * 1.5)
+        setTimeout(() =>
+          this.validateClaim(claim, nextRetryInterval).catch(err =>
+            this.master._log.error(`Attempt to retry claim validation failed: ${err.message}`)
+          ),
+        retryInterval)
+      }
+    }
+
+    return this.queue.add(async () => {
+      const oldClaim = this.account.bestIncomingClaim
+      const wrongChannel = oldClaim
+        // New claim is using different channel from the old claim
+        && oldClaim.channelId !== claim.channelId
+        // Old channel is still open (if it was closed, a new claim is acceptable)
+        && (await this.updateChannelCache(oldClaim.channelId))
+      if (wrongChannel) {
+        throw new Error(`account ${this.account.accountName} must use channel ${oldClaim!.channelId}`)
+      }
+
+      let channel: IChannel | undefined = this.channelCache[claim.channelId]
+      // Fetch channel state from network if:
+      // 1) No claim/channel is linked to the account
+      // 2) The channel isn't cached
+      // 3) Claim value is greater than cached channel value (e.g. possible on-chain deposit)
+      const shouldFetchChannel = !oldClaim || !channel
+        || new BigNumber(claim.value).gt(channel.value)
+      if (shouldFetchChannel) {
+        channel = await this.updateChannelCache(claim.channelId)
+      }
+
+      if (!channel) {
+        this.master._log.error(`Failed to validate claim: channel ${
+          claim.channelId
+        } doesn't exist (if recently opened, it may still be propagating)`)
+
+        return retryValidation()
+      }
+
+      if (new BigNumber(claim.value).lte(0)) {
+        throw new Error(`value of claim is 0 or negative`)
+      }
+
+      const contractAddress = this.master._network!.unidirectional.address
+      const paymentDigest = Web3.utils.soliditySha3(contractAddress, claim.channelId, claim.value)
+      const paymentDigestBuffer = Buffer.from(Web3.utils.hexToBytes(paymentDigest))
+      const ethPaymentDigest = Buffer.concat([
+        Buffer.from(SIGN_PREFIX), paymentDigestBuffer
+      ])
+      const senderAddress = ethRecover(claim.signature, keccak256(ethPaymentDigest))
+      const isValidSignature = senderAddress === channel.sender
+      if (!isValidSignature) {
+        throw new Error(`signature is invalid, or sender is using contracts on a different network`)
+      }
+
+      const oldClaimValue = new BigNumber(oldClaim ? oldClaim.value : 0)
+      const newClaimValue = BigNumber.min(channel.value, claim.value)
+      let claimIncrement = newClaimValue.minus(oldClaimValue)
+      if (claimIncrement.eq(0)) {
+        this.master._log.trace(`Disregarding incoming claim: value of ${
+          format(claim.value, Unit.Wei)
+        } is same as previous claim (if peer recently deposited, it may still be propagating)`)
+
+        return retryValidation()
+      } else if (claimIncrement.lt(0)) {
+        throw new Error(`claim value of ${format(claim.value, Unit.Wei)} is less than previous claim for ${format(oldClaimValue, Unit.Wei)}`)
+      }
+
+      // If a new channel is being linked to the account, perform additional validation
+      const linkNewChannel = !oldClaim || claim.channelId !== oldClaim.channelId
+      if (linkNewChannel) {
+        // Each channel key is a mapping of channelId -> accountName to ensure no channel can be linked to multiple accounts
+        // No race condition: a new linked channel will be cached at the end of this closure
+        const channelKey = `${claim.channelId}:incoming-channel`
+        await this.master._store.load(channelKey)
+        const linkedAccount = this.master._store.get(channelKey)
+        const canLinkChannel = !linkedAccount || linkedAccount === this.account.accountName
+        if (!canLinkChannel) {
+          throw new Error(`channel ${claim.channelId} is already linked to a different account`)
+        }
+
+        // Check the channel is to the server's address
+        // (only check for new channels, not per claim, in case the server restarts and changes config)
+        const amReceiver = channel.receiver.toLowerCase() === this.master._ethereumAddress.toLowerCase()
+        if (!amReceiver) {
+          throw new Error(`the recipient for incoming channel ${claim.channelId} is not ${this.master._ethereumAddress}`)
+        }
+
+        // Confirm the settling period for the channel is above the minimum
+        const isAboveMinSettlementPeriod = channel.settlingPeriod.gte(this.master._minIncomingSettlementPeriod)
+        if (!isAboveMinSettlementPeriod) {
+          throw new Error(`channel ${channel.channelId} has settling period of ${channel.settlingPeriod} blocks,`
+            + `below floor of ${this.master._minIncomingSettlementPeriod} blocks`)
+        }
+
+        // Deduct the initiation fee (e.g. this could be used to cover the cost of the claim tx to close the channel)
+        claimIncrement = claimIncrement.minus(this.master._incomingChannelFee)
+        if (claimIncrement.lt(0)) {
+          throw new Error(`claim value of ${format(newClaimValue, Unit.Wei)} is insufficient to cover the initiation fee of ` +
+            `${format(this.master._incomingChannelFee, Unit.Wei)}`)
+        }
+
+        this.master._store.set(channelKey, this.account.accountName)
+        this.master._log.trace(`Incoming channel ${claim.channelId} is now linked to account ${this.account.accountName}`)
+      }
+
+      this.account.bestIncomingClaim = claim
+      this.master._log.info(`Accepted incoming claim from account ${this.account.accountName} for ${format(claimIncrement, Unit.Wei)}`)
+
+      // Start the channel watcher if it wasn't running
+      if (!this.watcher) {
+        this.watcher = this.startChannelWatcher()
+      }
+
+      const amount = convert(claimIncrement, Unit.Wei, Unit.Gwei).dp(0, BigNumber.ROUND_DOWN)
+      this.subBalance(amount)
+
+      await this.moneyHandler(amount.toString())
     }, {
       priority: TaskPriority.Incoming
     })
@@ -793,9 +849,8 @@ export default class EthereumAccount {
     type: Type.TYPE_ILP_PREPARE,
     typeString?: 'ilp_prepare',
     data: IlpPrepare
-  }, responsePacket: IlpPacket): void {
-    const isFulfill = responsePacket.type === Type.TYPE_ILP_FULFILL
-    if (isFulfill) {
+  }, { data: response }: IlpPacket): void {
+    if (isFulfill(response)) {
       this.master._log.trace(`Received a FULFILL in response to the forwarded PREPARE from sendData`)
 
       // Update balance to reflect that we owe them the amount of the FULFILL
@@ -808,11 +863,12 @@ export default class EthereumAccount {
         this.master._log.trace(`Failed to fulfill response to PREPARE: ${err.message}`)
         throw new Errors.InternalError(err.message)
       }
+    } else if (isReject(response)) {
+      this.master._log.trace(`Received a ${response.code} REJECT in response to the forwarded PREPARE from sendData`)
     }
 
     // Attempt to settle on fulfills and* T04s (to resolve stalemates)
-    const shouldSettle = isFulfill ||
-      (responsePacket.type === Type.TYPE_ILP_REJECT && responsePacket.data.code === 'T04')
+    const shouldSettle = isFulfill(response) || (isReject(response) && response.code === 'T04')
     if (shouldSettle) {
       this.attemptSettle().catch((err: Error) => {
         this.master._log.trace(`Error queueing an outgoing settlement: ${err.message}`)


### PR DESCRIPTION
Case: Sender opens a channel and sends a claim to the receiver, but the receiver doesn't see the new channel yet, rejecting the claim (due to latency in block propagation--even if both are using Infura).

Previously, the solution was to wait 2 seconds after opening/depositing -- which worked most of the time, but wasn't very robust.

New behavior: in scenarios where there was a possible on-chain funding tx, the receiver will retry validating the claim a number of times, with a time backoff, before giving up.